### PR TITLE
Added string support and setylim for stat_smooth

### DIFF
--- a/@gramm/private/unique_and_sort.m
+++ b/@gramm/private/unique_and_sort.m
@@ -25,7 +25,7 @@ end
 
 %Clean up uniques
 if ~iscell(x)
-    if ~old_matlab_2013 && ~iscategorical(y)
+    if ~old_matlab_2013 && ~iscategorical(y) && ~isstring(y) 
         y(isnan(y)) = []; % remove all nans
     end
 else

--- a/@gramm/private/unique_and_sort.m
+++ b/@gramm/private/unique_and_sort.m
@@ -25,7 +25,7 @@ end
 
 %Clean up uniques
 if ~iscell(x)
-    if ~old_matlab_2013 && ~iscategorical(y) && ~isstring(y) 
+    if ~old_matlab_2013 && ~iscategorical(y)
         y(isnan(y)) = []; % remove all nans
     end
 else

--- a/@gramm/stat_smooth.m
+++ b/@gramm/stat_smooth.m
@@ -34,6 +34,7 @@ my_addParameter(p,'lambda',[]);
 my_addParameter(p,'geom','area');
 my_addParameter(p,'method','eilers');
 my_addParameter(p,'npoints',200);
+my_addParameter(p,'setylim',false);
 parse(p,varargin{:});
 
 %Set default lambdas
@@ -262,6 +263,23 @@ else
     obj.results.stat_smooth{obj.result_ind,1}.y=newy;
     obj.results.stat_smooth{obj.result_ind,1}.yci=yci;
     
+    %Do we set the y limits according to the smoothed curves or to
+    %the original data ?
+    if params.setylim
+        if sum(sum(isnan(yci)))~=numel(yci) %We only do this if yci is not weird
+            if obj.firstrun(obj.current_row,obj.current_column) %Initialize for the first run in the subplot
+                obj.plot_lim.maxy(obj.current_row,obj.current_column)=max(max(yci));
+                obj.plot_lim.miny(obj.current_row,obj.current_column)=min(min(yci));
+            else %Update for subsequent runs in the subplot
+                if max(max(yci))>obj.plot_lim.maxy(obj.current_row,obj.current_column)
+                    obj.plot_lim.maxy(obj.current_row,obj.current_column)=max(max(yci));
+                end
+                if min(min(yci))<obj.plot_lim.miny(obj.current_row,obj.current_column)
+                    obj.plot_lim.miny(obj.current_row,obj.current_column)=min(min(yci));
+                end
+            end
+        end
+    end
     
     hndl=plotci(obj,newx,newy,yci,draw_data,params.geom);
     

--- a/examples.m
+++ b/examples.m
@@ -849,8 +849,8 @@ g(2,2).stat_smooth('method','moving','lambda',31);
 g(2,2).set_title('''method'',''moving''');
 
 
-g(2,3).stat_smooth('method','loess','lambda',0.1);
-g(2,3).set_title('''method'',''loess''');
+g(2,3).stat_smooth('method','loess','lambda',0.1,'setylim',true);
+g(2,3).set_title('''method'',''loess'',''setylim'',''true''');
 
 g.set_title('Options for stat_smooth()');
 g.draw();

--- a/functionSignatures.json
+++ b/functionSignatures.json
@@ -135,7 +135,8 @@
             {"name":"lambda","kind":"namevalue","type":"numeric"},
             {"name":"npoints","kind":"namevalue","type":"numeric"},
             {"name":"width","kind":"namevalue","type":"numeric"}, 
-            {"name":"geom","kind":"namevalue","type":"choices={'area','lines','line','solid_area','black_errorbar','errorbar','bar','point','area_only'}"}
+            {"name":"geom","kind":"namevalue","type":"choices={'area','lines','line','solid_area','black_errorbar','errorbar','bar','point','area_only'}"},
+			{"name":"setylim","kind":"namevalue","type":"choices={1,0}"}
 		]
 },
 "gramm.stat_glm":


### PR DESCRIPTION
I tested it and I don't think this breaks anything.

Two changes:

I copied setylim from stat_summary into stat_smooth so it works for both

I added string support to unique_and_sort.m so you can have string variables as well as categorical and cells. Might be able to add this to unique_non_nan.m but I don't know enough about it.
