### PR TITLE
[stat_boxplot] add option to not show outlier

### DIFF
--- a/gramm/@gramm/stat_boxplot.m
+++ b/gramm/@gramm/stat_boxplot.m
@@ -1,3 +1,4 @@
+
 function obj=stat_boxplot(obj,varargin)
 %stat_boxplot() Create box and whiskers plots
 %
@@ -12,6 +13,8 @@ function obj=stat_boxplot(obj,varargin)
 % - 'dodge' allows to set the spacing between boxes of
 %   different colors within an unique value of x.
 % - 'width' allows to set the width of the individual boxes.
+% - 'outliers' set to false to hide outliers. If the value is not set,
+% outliers are not plotted when geom_point() or geom_jitter() are used.
 % See the documentation of stat_summary() for the behavior of
 % 'dodge' and 'width'
 
@@ -19,11 +22,19 @@ p=inputParser;
 my_addParameter(p,'width',0.6);
 my_addParameter(p,'dodge',0.7);
 my_addParameter(p,'notch',false);
-my_addParameter(p,'outlier',true);
+my_addParameter(p,'outliers',true);
 
 parse(p,varargin{:});
 
-obj.geom=vertcat(obj.geom,{@(dobj,dd)my_boxplot(dobj,dd,p.Results)});
+params = p.Results;
+%Did the user specify the outliers settings
+if any(strcmp(p.UsingDefaults,'outliers'))
+    params.default_outliers = true;
+else
+    params.default_outliers = false;
+end
+
+obj.geom=vertcat(obj.geom,{@(dobj,dd)my_boxplot(dobj,dd,params)});
 obj.results.stat_boxplot={};
 
 end
@@ -138,8 +149,23 @@ end
 obj.results.stat_boxplot{obj.result_ind,1}.lower_whisker_handle=line([boxmid' ; boxmid'],[p(:,1)' ; p(:,2)'],'Color','k');
 obj.results.stat_boxplot{obj.result_ind,1}.upper_whisker_handle=line([boxmid' ; boxmid'],[p(:,end-1)' ; p(:,end)'],'Color','k');
 
+%Auto detect geom_point and geom_jitter to deactivate outlier plotting if
+%not explicitly set
+if any(cellfun(@(f)string(func2str(f)).contains(["jitter" "point"]),obj.geom))
+    if params.default_outliers
+        params.outliers = false;
+        if any(obj.firstrun,"all")
+            disp("geom_jitter() or geom_point() are present, stat_boxplot() outliers ignored ");
+        end
+    else
+        if params.outliers && any(obj.firstrun,"all")
+            disp("geom_jitter() or geom_point() are present and stat_boxplot() outliers are plotted");
+        end
+    end
+end
+
 %Draw outliers
-if params.outlier
+if params.outliers
     obj.results.stat_boxplot{obj.result_ind,1}.outliers_handle=plot(boxmid(outliersx),outliersy,'o','MarkerEdgeColor','none','MarkerFaceColor',draw_data.color);
 end
 

--- a/gramm/@gramm/stat_boxplot.m
+++ b/gramm/@gramm/stat_boxplot.m
@@ -19,6 +19,8 @@ p=inputParser;
 my_addParameter(p,'width',0.6);
 my_addParameter(p,'dodge',0.7);
 my_addParameter(p,'notch',false);
+my_addParameter(p,'outlier',true);
+
 parse(p,varargin{:});
 
 obj.geom=vertcat(obj.geom,{@(dobj,dd)my_boxplot(dobj,dd,p.Results)});
@@ -137,7 +139,9 @@ obj.results.stat_boxplot{obj.result_ind,1}.lower_whisker_handle=line([boxmid' ; 
 obj.results.stat_boxplot{obj.result_ind,1}.upper_whisker_handle=line([boxmid' ; boxmid'],[p(:,end-1)' ; p(:,end)'],'Color','k');
 
 %Draw outliers
-obj.results.stat_boxplot{obj.result_ind,1}.outliers_handle=plot(boxmid(outliersx),outliersy,'o','MarkerEdgeColor','none','MarkerFaceColor',draw_data.color);
+if params.outlier
+    obj.results.stat_boxplot{obj.result_ind,1}.outliers_handle=plot(boxmid(outliersx),outliersy,'o','MarkerEdgeColor','none','MarkerFaceColor',draw_data.color);
+end
 
 %Adjust limits
 obj.plot_lim.maxx(obj.current_row,obj.current_column)=max(max(boxright),obj.plot_lim.maxx(obj.current_row,obj.current_column));

--- a/gramm/functionSignatures.json
+++ b/gramm/functionSignatures.json
@@ -237,7 +237,8 @@
 			{"name":"obj","kind":"required","type":"gramm"},
             {"name":"width","kind":"namevalue","type":"numeric"},
             {"name":"dodge","kind":"namevalue","type":"numeric"},
-            {"name":"notch","kind":"namevalue","type":"choices={1,0}"}
+            {"name":"notch","kind":"namevalue","type":"choices={1,0}"},
+            {"name":"outlier","kind":"namevalue","type":"choices={1,0}"}
 		]
 },
 "gramm.stat_violin":

--- a/gramm/functionSignatures.json
+++ b/gramm/functionSignatures.json
@@ -238,7 +238,7 @@
             {"name":"width","kind":"namevalue","type":"numeric"},
             {"name":"dodge","kind":"namevalue","type":"numeric"},
             {"name":"notch","kind":"namevalue","type":"choices={1,0}"},
-            {"name":"outlier","kind":"namevalue","type":"choices={1,0}"}
+            {"name":"outliers","kind":"namevalue","type":"choices={1,0}"}
 		]
 },
 "gramm.stat_violin":


### PR DESCRIPTION
Hello, 

Thanks a lot for creating this toolbox. This PR is here to add the option to stat_boxplot to not show the outliers. 
The issue arises when displaying a boxplot + jitterpoint, as the outlier will end up being displayed twice.

There is a solution to hide the outliers after, since we have the handle, but I think it's cleaner to be able to not show them (also I often forget to hide them). 

Here is a small example:

```matlab

x=repmat(1:10,1,100);
catx=repmat({'A' 'B' 'C' 'F' 'E' 'D' 'G' 'H' 'I' 'J'},1,100);
y=randn(1,1000)*3;
c=repmat([1 1 1 1 1 1 1 1 1 1    1 1 2 2 2 2 2 3 2 2     2 1 1 2 2 2 2 3 2 3     2 1 1 2 2 2 2 2 2 2],1,25);
y=2+y+x+c*0.5;

clear g
g(1,1)=gramm('x',catx,'y',y,'color',c);
g(1,1).geom_jitter()
g(1,1).stat_boxplot()

g(1,2)=gramm('x',catx,'y',y,'color',c);
g(1,2).geom_jitter()
g(1,2).stat_boxplot('outlier', false)


figure;
g.draw()

```


For the bloxplot, it might actually be nice to have a face_alpha parameter to set the alpha of the box. I often change it to 100% after the draw to see all the point behind the box. 

