### PR TITLE
Fix colormap comment typo

### DIFF
--- a/examples_dev.m
+++ b/examples_dev.m
@@ -1120,7 +1120,7 @@ g(1,3).stat_summary('geom',{'bar'},'dodge',0);
 g(1,3).set_color_options('lightness_range',[0 95],'chroma_range',[0 0]);
 g(1,3).set_title('Modified LCH (''lightness'' groups)','FontSize',12);
 
-%Go back to Matlab's defauls colormap
+%Go back to Matlab's default colormap
 g(2,1).set_color_options('map','matlab');
 g(2,1).set_title('Matlab 2014B+ ','FontSize',12);
 

--- a/gramm/examples/example_color_palette_customization.m
+++ b/gramm/examples/example_color_palette_customization.m
@@ -32,7 +32,7 @@ g(1,3).stat_summary('geom',{'bar'},'dodge',0);
 g(1,3).set_color_options('lightness_range',[0 95],'chroma_range',[0 0]);
 g(1,3).set_title('Modified LCH (''lightness'' groups)','FontSize',12);
 
-%Go back to Matlab's defauls colormap
+%Go back to Matlab's default colormap
 g(2,1).set_color_options('map','matlab');
 g(2,1).set_title('Matlab 2014B+ ','FontSize',12);
 


### PR DESCRIPTION
Summary
- Fix a repeated typo in the color palette customization example comments.

Validation
- git diff --check

This is a comment-only change, so I did not run the MATLAB examples.